### PR TITLE
Create module avere_facts to retrieve Avere cluster configuration data

### DIFF
--- a/library/avere_facts.py
+++ b/library/avere_facts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.avere \
+    import avere_api_client, avere_host_argument_spec
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=avere_host_argument_spec(),
+        supports_check_mode=True,
+    )
+
+    result = {'changed': False}
+
+    client = avere_api_client(module)
+
+    result['cache_policies'] = client.cachePolicy.list()
+
+    result['cloud_credentials'] = client.corefiler.listCredentials()
+
+    result['cluster'] = client.cluster.get()
+
+    corefilers = client.corefiler.list()
+    result['corefilers'] = {}
+    for corefiler in corefilers:
+        corefiler_facts = client.corefiler.get(corefiler)
+        corefiler_facts[corefiler]['nfs_exports'] = \
+            client.corefiler.listExports(corefiler)
+        result['corefilers'].update(corefiler_facts)
+
+    result['migrations'] = client.migration.list()
+
+    result['schedules'] = client.cluster.listSchedules()
+
+    result['snapshot_policies'] = client.snapshot.listPolicies()
+
+    vservers = client.vserver.list()
+    result['vservers'] = {}
+    for vserver in vservers:
+        vserver_facts = client.vserver.get(vserver)
+        vserver_facts[vserver]['cifs_shares'] = \
+            client.cifs.listShares(vserver)
+        vserver_facts[vserver]['junctions'] = \
+            client.vserver.listJunctions(vserver)
+        vserver_facts[vserver]['nfs_exports'] = {}
+        for corefiler in corefilers:
+            vserver_facts[vserver]['nfs_exports'][corefiler] = \
+                client.nfs.listExports(vserver, corefiler)
+        nfs_export_policies = client.nfs.listPolicies(vserver)
+        vserver_facts[vserver]['nfs_export_policies'] = {}
+        for nfs_export_policy in nfs_export_policies:
+            (vserver_facts[vserver]
+                ['nfs_export_policies'][nfs_export_policy]) = \
+                client.nfs.listRules(vserver, nfs_export_policy)
+        result['vservers'].update(vserver_facts)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/avere.py
+++ b/module_utils/avere.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import vFXT
+
+
+def avere_host_argument_spec():
+    return dict(
+        hostname=dict(type='str', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+    )
+
+
+def avere_api_client(module):
+    hostname = module.params.get('hostname')
+    username = module.params.get('username')
+    password = module.params.get('password')
+
+    client = vFXT.xmlrpcClt.getXmlrpcClient(
+        "http://{0}/cgi-bin/rpc2.py".format(hostname),
+        do_cert_checks=False
+    )
+
+    login = client.system.login(
+        username.encode('base64'),
+        password.encode('base64')
+    )
+    if login != 'success':
+        raise Exception(result)
+
+    return client


### PR DESCRIPTION
This is the first of a family of modules to manage Avere OS FXT/vFXT storage clusters using Ansible. This one is read-only, gathering configuration data from a cluster. Some notes:

* Avere's Python SDK code is available in PIP, but isn't very nicely named for what it actually is (`vFXT`); it has a general-purpose Avere OS API client in it that works with physical FXT clusters, too, not just vFXT clusters.
* This code currently disables TLS certificate verification, which is not advisable. I intend to correct this soon, but I think it's reasonable to merge this before that's been done.
* I can provide testing instructions on this before reviews are finalized. but I wanted to submit this now so people can read the code and begin asking any questions.